### PR TITLE
Update for Dragonflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: BigWigsMods/packager@master

--- a/HideTalkingHead.lua
+++ b/HideTalkingHead.lua
@@ -1,5 +1,6 @@
 -- License: Public Domain
 
-hooksecurefunc("TalkingHeadFrame_PlayCurrent", function()
+hooksecurefunc(TalkingHeadFrame, "PlayCurrent", function()
 	TalkingHeadFrame:Hide()
 end)
+

--- a/HideTalkingHead.toc
+++ b/HideTalkingHead.toc
@@ -1,10 +1,8 @@
-## Interface: 90005
+## Interface: 100000
 ## Version: @project-version@
 ## Title: HideTalkingHead
 ## Notes: Hides that message dialog
 ## Author: Ketho @ EU-Boulderfist
-## LoadOnDemand: 1
-## LoadWith: Blizzard_TalkingHeadUI
 ## X-Curse-Project-ID: 101111
 ## X-WoWI-ID: 23914
 


### PR DESCRIPTION
Key changes:
Remove load-on-demand functionality as the Talking Head is no longer an addon.
Update the code to reference the frame's function instead of a global.
Update the packager's checkout logic to fix #1.